### PR TITLE
Update 02-Problem-Statement.md

### DIFF
--- a/Project-Catalyst/Proposal/02-Problem-Statement/02-Problem-Statement.md
+++ b/Project-Catalyst/Proposal/02-Problem-Statement/02-Problem-Statement.md
@@ -1,8 +1,8 @@
 # 02-Problem-Statement (140 char. limit)
 
-Trust in central authority inhibits innovation.
+Trust in central authority blocks free inquiry.
 
-Closed sources block free inquiry.
+Closed sources inhibits innovation.
 
 Duplication of standards wastes resources.
 


### PR DESCRIPTION
## Swapped endings between **Trust in central authority** and **Closed sources**.
### Rationale: 
A blind `Trust in central authority` blocks free inquiry by offloading responsibility to that Authority.
`Closed sources inhibit innovation` by preventing community collaboration and review
