### PR TITLE
Central to arbitrary authority

### DIFF
--- a/Project-Catalyst/Proposal/02-Problem-Statement/02-Problem-Statement.md
+++ b/Project-Catalyst/Proposal/02-Problem-Statement/02-Problem-Statement.md
@@ -1,6 +1,6 @@
 # 02-Problem-Statement (140 char. limit)
 
-Trust in central authority blocks free inquiry.
+Trust in arbitrary authority blocks free inquiry.
 
 Closed sources inhibit innovation.
 


### PR DESCRIPTION
A central authority does not necessarily block free inquiry if it has a rationale. 
It is arbitrary authority without reason that blocks free inquiry.