### PR TITLE
Update Governance Holding Page

### DIFF
--- a/Project-Catalyst/Reports/03-Governance.md
+++ b/Project-Catalyst/Reports/03-Governance.md
@@ -3,3 +3,5 @@
 Holding Page
 
 This deliverable will be a "leap of faith" interaction with voters to assess whether QA-DAO should be funded $5 given the delivery of 80% of outputs (1 -5).
+
+The Governance of this proposal will transfer to the QA-DAO Open Source Repository (https://github.com/Quality-Assurance-DAO/DAO-Open-Source). This is already active in conducting a study of OccamFi's OCC token launch and will be supplemented by output documents from this Fund 5 proposal.


### PR DESCRIPTION
Update Governance Holding Page to refer to active studies on the QA-DAO Open Source repository and to indicate that completed outputs from the Fund 5 Proposal repository will be transferred to the QA-DAO Open Source repository .